### PR TITLE
Accept bytes input

### DIFF
--- a/aztec_code_generator.py
+++ b/aztec_code_generator.py
@@ -427,7 +427,7 @@ def optimal_sequence_to_bits(optimal_sequence):
         # read one item from sequence
         ch = sequence.pop(0)
         if binary:
-            out_bits += bin(ord(ch))[2:].zfill(char_size.get(mode))
+            out_bits += bin(ch)[2:].zfill(char_size.get(mode))
             binary_index += 1
             # resume previous mode at the end of the binary sequence
             if binary_index >= binary_seq_len:

--- a/aztec_code_generator.py
+++ b/aztec_code_generator.py
@@ -427,7 +427,11 @@ def optimal_sequence_to_bits(optimal_sequence):
         # read one item from sequence
         ch = sequence.pop(0)
         if binary:
-            out_bits += bin(ch)[2:].zfill(char_size.get(mode))
+            try: 
+                int_val = ord(ch)
+            except:
+                int_val = ch
+            out_bits += bin(int_val)[2:].zfill(char_size.get(mode))
             binary_index += 1
             # resume previous mode at the end of the binary sequence
             if binary_index >= binary_seq_len:


### PR DESCRIPTION
The module previously balks at `bytes()` input. Removing the `ord()` function on the input works for me, but might break something else. 

I am not sure if it makes sense to send a Python unicode string to the library anyhow, as I understand Aztec codes just encode 8-bit values (among others).