### PR TITLE
Fix ValueError thrown on specific byte sequence

### DIFF
--- a/aztec_code_generator.py
+++ b/aztec_code_generator.py
@@ -265,16 +265,34 @@ def find_optimal_sequence(data):
                             else:
                                 if x == 'binary':
                                     # TODO: review this
+                                    # Reviewed by jravallec
                                     if y == back_to[x]:
                                         # when return from binary to previous mode, skip mode change
                                         cur_seq[y] = cur_seq[x] + ['resume']
-                                    elif y == 'punct':
-                                        cur_seq[y] = cur_seq[x] + ['resume', 'M/L', 'P/L']
-                                        back_to[y] = 'punct'
-                                    elif y == 'upper' and back_to[x] == 'lower':
-                                        # when return from binary back to lower and then to upper
-                                        cur_seq[y] = cur_seq[x] + ['resume', 'M/L', 'U/L']
+                                    elif y == 'upper':
+                                        if back_to[x] == 'lower':
+                                            cur_seq[y] = cur_seq[x] + ['resume', 'M/L', 'U/L']
+                                        if back_to[x] == 'mixed':
+                                            cur_seq[y] = cur_seq[x] + ['resume', 'U/L']
                                         back_to[y] = 'upper'
+                                    elif y == 'lower':
+                                        cur_seq[y] = cur_seq[x] + ['resume', 'L/L']
+                                        back_to[y] = 'lower'
+                                    elif y == 'mixed':
+                                        cur_seq[y] = cur_seq[x] + ['resume', 'M/L']
+                                        back_to[y] = 'mixed'
+                                    elif y == 'punct':
+                                        if back_to[x] == 'mixed':
+                                            cur_seq[y] = cur_seq[x] + ['resume', 'P/L']
+                                        else:
+                                            cur_seq[y] = cur_seq[x] + ['resume', 'M/L', 'P/L']
+                                        back_to[y] = 'punct'
+                                    elif y == 'digit':
+                                        if back_to[x] == 'mixed':
+                                            cur_seq[y] = cur_seq[x] + ['resume', 'U/L', 'D/L']
+                                        else:
+                                            cur_seq[y] = cur_seq[x] + ['resume', 'D/L']
+                                        back_to[y] = 'digit'
                                 else:
                                     cur_seq[y] = cur_seq[x] + ['resume', '%s/L' % y.upper()[0]]
                                     back_to[y] = y
@@ -365,13 +383,21 @@ def find_optimal_sequence(data):
     result_seq = [x for x in result_seq if x != 'resume']
     # update binary sequences' extra sizes
     updated_result_seq = []
+    is_binary_length = False
     for i, c in enumerate(result_seq):
-        if c == 'B/S':
-            if result_seq[i + 1] > 31:
-                updated_result_seq.append(c)
+        if is_binary_length:
+            if c > 31:
                 updated_result_seq.append(0)
-                continue
-        updated_result_seq.append(c)
+                updated_result_seq.append(c - 31)
+            else:
+                updated_result_seq.append(c)
+            is_binary_length = False
+        else:
+            updated_result_seq.append(c)
+
+        if c == 'B/S':
+            is_binary_length = True
+            
     return updated_result_seq
 
 
@@ -430,7 +456,7 @@ def optimal_sequence_to_bits(optimal_sequence):
                 if not isinstance(seq_len, numbers.Number):
                     raise Exception('Binary sequence length must be a number')
                 out_bits += bin(seq_len)[2:].zfill(11)
-                binary_seq_len = seq_len
+                binary_seq_len = seq_len + 31
             binary = True
             binary_index = 0
         # update previous mode

--- a/test_aztec_code_generator.py
+++ b/test_aztec_code_generator.py
@@ -39,7 +39,7 @@ class Test(unittest.TestCase):
             'C', 'L/L', 'o', 'd', 'e', 'D/L', ' ', '2', 'U/S', 'D', 'P/S', '!'])
         self.assertEqual(find_optimal_sequence('a\xff'), ['B/S', 2, 'a', '\xff'])
         self.assertEqual(find_optimal_sequence('a' + '\xff' * 30), ['B/S', 31, 'a'] + ['\xff'] * 30)
-        self.assertEqual(find_optimal_sequence('a' + '\xff' * 31), ['B/S', 0, 32, 'a'] + ['\xff'] * 31)
+        self.assertEqual(find_optimal_sequence('a' + '\xff' * 31), ['B/S', 0, 1, 'a'] + ['\xff'] * 31)
         self.assertEqual(find_optimal_sequence('!#$%&?'), ['M/L', 'P/L', '!', '#', '$', '%', '&', '?'])
         self.assertEqual(find_optimal_sequence('!#$%&?\xff'), [
             'M/L', 'P/L', '!', '#', '$', '%', '&', '?', 'U/L', 'B/S', 1, '\xff'])
@@ -61,12 +61,11 @@ class Test(unittest.TestCase):
         self.assertEqual(find_optimal_sequence('ABCabc1a2b3eBC'), [
             'A', 'B', 'C', 'L/L', 'a', 'b', 'c', 'B/S', 6, '1', 'a', '2', 'b', '3', 'e', 'M/L', 'U/L', 'B', 'C'])
         self.assertEqual(find_optimal_sequence('0a|5Tf.l'), [
-            'D/L', '0', 'U/L', 'L/L', 'a', 'M/L', '|', 'U/L',
-            'D/L', '5', 'U/L', 'L/L', 'U/S', 'T', 'f', 'P/S', '.', 'l'])
+            'B/S', 5, '0', 'a', '|', '5', 'T', 'L/L', 'f', 'P/S', '.', 'l'])
         self.assertEqual(find_optimal_sequence('*V1\x0c {Pa'), [
-            'P/S', '*', 'V', 'B/S', 2, '1', '\x0c', ' ', 'P/S', '{', 'P', 'L/L', 'a'])
+            'P/S', '*', 'V', 'B/S', 5, '1', '\x0c', ' ', '{', 'P', 'L/L', 'a'])
         self.assertEqual(find_optimal_sequence('~Fxlb"I4'), [
-            'M/L', '~', 'U/L', 'D/L', 'U/S', 'F', 'U/L', 'L/L', 'x', 'l', 'b', 'D/L', 'P/S', '"', 'U/S', 'I', '4'])
+            'B/S', 7, '~', 'F', 'x', 'l', 'b', '"', 'I', 'D/L', '4'])
         self.assertEqual(find_optimal_sequence('\\+=R?1'), [
             'M/L', '\\', 'P/L', '+', '=', 'U/L', 'R', 'D/L', 'P/S', '?', '1'])
 


### PR DESCRIPTION
There is this issue that appears in the recent version of the package:
```
ValueError: b'\r\n' is not in list
```

The bug has been fixed in the recent version of https://github.com/delimitry/aztec_code_generator
More about the issue and the fix: https://github.com/delimitry/aztec_code_generator/issues/7